### PR TITLE
Updated MQTT and Home Assistant integration

### DIFF
--- a/hassio_mqtt.cpp
+++ b/hassio_mqtt.cpp
@@ -1,5 +1,5 @@
 /*
-  Project:      Powered Air Quality
+  Project:      Powered Air Quality & Climatron
   Description:  write sensor data to hassio_mqtt
 */
 
@@ -7,192 +7,162 @@
  * Additional routines for use in an MQTT-enabled environment with Home Assistant, allowing
  * sensor readings to be reported to Home Assistant.   
  * 
- * Requires the following addition to configuration.yaml for Home Assistant, with the
- * state topic declared to match MQTT_HASSIO_STATE as defined in config.h. Also, Unique IDs, 
- * which enable additional UI customization features for the sensors in Home Assistant,
- * can be generated here: https://www.uuidgenerator.net/version1.
+ * For Home Assistant to recognize Climatron sensors as entities and allow their display,
+ * integration into automations, etc., its configuration.yaml file needs to modified to incorporate
+ * proper details of each of those sensors and Climatron overall as a device.  A future version
+ * of Home Assistant integration for Climatron will implement auto-discovery so those details
+ * are published directly by Climatron to Home Assistant.
+ *
+ * In the meantime manual integration is required.  This looks like the following, where
+ * <site>, <location>, and <room> are replaced with device details as set in secrets.h and/or
+ * through the onboard configuration portal.
 
-   mqtt:
-    sensor:
-     - name: "Temperature"
+# Configuration for Climatron-0857 integration with Home Assistant
+mqtt:
+  sensor:
+    - name: "Temperature"
       device_class: "temperature"
-      state_topic: "homeassistant/sensor/aqi-1/state"
       unit_of_measurement: "°F"
-      unique_id: "-- GENERATE A UUID TO USE HERE --"
-      value_template: "{{ value_json.temperature }}"
+      state_topic: "homeassistant/<site>>/<location>/<room>/Climatron-0857/state"
+      unique_id: "Climatron-0857-temperature"
+      value_template: "{{ value_json.temperatureF }}"
+      state_class: "measurement"
+      device:
+        name: "Climatron"
+        identifiers:
+          - "Climatron-0857" 
     - name: "Humidity"
       device_class: "humidity"
-      state_topic: "homeassistant/sensor/aqi-1/state"
       unit_of_measurement: "%"
-      unique_id: "-- GENERATE A UUID TO USE HERE --"
+      state_topic: "homeassistant/<site>>/<location>/<room>/Climatron-0857/state"
+      unique_id: "Climatron-0857-humidity"
       value_template: "{{ value_json.humidity }}"
+      state_class: "measurement"
+      device:
+        name: "Climatron"
+        identifiers:
+          - "Climatron-0857" 
+    - name: "CO2"
+      device_class: "carbon_dioxide"
+      unit_of_measurement: "ppm"
+      state_topic: "homeassistant/<site>>/<location>/<room>/Climatron-0857/state"
+      unique_id: "Climatron-0857-co2"
+      value_template: "{{ value_json.co2 }}"
+      state_class: "measurement"
+      device:
+        name: "Climatron"
+        identifiers:
+          - "Climatron-0857" 
     - name: "PM2.5"
       device_class: "pm25"
-      state_topic: "homeassistant/sensor/aqi-1/state"
+      state_topic: "homeassistant/<site>>/<location>/<room>/Climatron-0857/state"
       unit_of_measurement: "µg/m³"
-      unique_id: "-- GENERATE A UUID TO USE HERE --"
+      unique_id: "Climatron-0857-pm25"
       value_template: "{{ value_json.pm25 }}"
+      state_class: "measurement"
+      device:
+        name: "Climatron"
+        identifiers:
+          - "Climatron-0857" 
     - name: "AQI"
       device_class: "aqi"
-      state_topic: "homeassistant/sensor/aqi-1/state"
-      unit_of_measurement: "AQI"
-      unique_id: "-- GENERATE A UUID TO USE HERE --"
+      state_topic: "homeassistant/<site>>/<location>/<room>/Climatron-0857/state"
+      unique_id: "Climatron-0857-aqi"
       value_template: "{{ value_json.aqi }}"
+      state_class: "measurement"
+      device:
+        name: "Climatron"
+        identifiers:
+          - "Climatron-0857" 
+    - name: "VOCIndex"
+      device_class: "aqi"
+      state_topic: "homeassistant/<site>>/<location>/<room>/Climatron-0857/state"
+      unique_id: "Climatron-0857-vocIndex"
+      value_template: "{{ value_json.vocIndex }}"
+      state_class: "measurement"
+      device:
+        name: "Climatron"
+        identifiers:
+          - "Climatron-0857" 
+    - name: "NOxIndex"
+      device_class: "aqi"
+      state_topic: "homeassistant/<site>>/<location>/<room>/Climatron-0857/state"
+      unique_id: "Climatron-0857-noxIndex"
+      value_template: "{{ value_json.noxIndex }}"
+      state_class: "measurement"
+      device:
+        name: "Climatron"
+        identifiers:
+          - "Climatron-0857" 
  */
 
 #include "Arduino.h"
 
 // hardware and internet configuration parameters
 #include "config.h"
+#include "powered_air_quality.h"  // overall header info for Powered Air Quality
 // private credentials for network, MQTT, weather provider
 #include "secrets.h"
 
-// Shared helper function
-  extern void debugMessage(String messageText, int messageLevel);
-
 #if defined MQTT && defined HASSIO_MQTT
   // MQTT setup
-  #include <Adafruit_MQTT.h>
-  #include <Adafruit_MQTT_Client.h>
+  #include <PubSubClient.h>
   #include <ArduinoJson.h>
-  extern Adafruit_MQTT_Client aq_mqtt;
+  extern PubSubClient mqtt;
 
-    // The code below attempts to enable MQTT auto-discovery for Home Assistant,
-  // but so far doesn't work to do that.  Instead this function isn't called from
-  // post_mqtt(), and manual sensor configuration is enabled in the Home Assistant
-  // configuration file.  See hassio_mqtt.cpp for more details.
-  #define TCONFIG_TOPIC "homeassistant/sensor/pm25-1T/config"
-  #define HCONFIG_TOPIC "homeassistant/sensor/pm25-1H/config"
-  #define PCONFIG_TOPIC "homeassistant/sensor/pm25-1P/config"
-  #define ACONFIG_TOPIC "homeassistant/sensor/pm25-1A/config"
-  // #define VCONFIG_TOPIC "homeassistant/sensor/pm25-1V/config"
-  #define VCONFIG_TOPIC "homeassistant/sensor/pm25-1C/config"
-
-  void hassio_mqtt_setup() {
-    const int capacity = JSON_OBJECT_SIZE(5);
-    StaticJsonDocument<capacity> doc;
-
-    // Declare buffer to hold serialized object
-    char output[1024];
-    String topic;
-    // Generate the device state topic for Home Assistant using deployment parameters from
-    // config.h.  Note that this must match the state topic as specified in Home Assiatant's
-    // configuration file (configuration.yaml) for this device.
-    topic = String(DEVICE_SITE) + "/" + String(DEVICE) + "/" + String(DEVICE_ID) + "/state";
-
-    // Create MQTT publish objects for the config channels
-    Adafruit_MQTT_Publish tconfigPub = Adafruit_MQTT_Publish(&aq_mqtt,TCONFIG_TOPIC);
-    Adafruit_MQTT_Publish hconfigPub = Adafruit_MQTT_Publish(&aq_mqtt,HCONFIG_TOPIC);
-    Adafruit_MQTT_Publish pconfigPub = Adafruit_MQTT_Publish(&aq_mqtt,PCONFIG_TOPIC);
-    Adafruit_MQTT_Publish aconfigPub = Adafruit_MQTT_Publish(&aq_mqtt,ACONFIG_TOPIC);
-    // Adafruit_MQTT_Publish vconfigPub = Adafruit_MQTT_Publish(&aq_mqtt,VCONFIG_TOPIC);
-    Adafruit_MQTT_Publish vconfigPub = Adafruit_MQTT_Publish(&aq_mqtt,CCONFIG_TOPIC);
-
-
-    debugMessage(String("Configuring PM25 for Home Assistant MQTT auto-discovery"),1);
-    // Create config info for temperature sensor
-    doc["device_class"] = "temperature";
-    doc["name"] = "Temperature";
-    doc["state_topic"] = topic.c_str();
-    doc["unit_of_measurement"] = "°F";
-    doc["value_template"] = "{{ value_json.temperature}}";
-
-    serializeJson(doc,output);
-    // Publish temperature config to its topic (TCONFIG_TOPIC) as a retained message
-    debugMessage(output,1);
-    tconfigPub.publish(output,true);
-
-    // Reset config data for humidity sensor
-    doc["device_class"] = "humidity";
-    doc["name"] = "Humidity";
-    doc["state_topic"] = topic.c_str();
-    doc["unit_of_measurement"] = "%";
-    doc["value_template"] = "{{ value_json.humidity}}";
-
-    serializeJson(doc,output);
-    // Publish humidity config to its topic (HCONFIG_TOPIC) as a retained message
-    debugMessage(output,1);
-    hconfigPub.publish(output,true);
-
-    // Reset config data for pm25 sensor
-    doc["device_class"] = "pm25";
-    doc["name"] = "pm25";
-    doc["state_topic"] = topic.c_str();
-    doc["unit_of_measurement"] = "ppm";
-    doc["value_template"] = "{{ value_json.co2}}";
-
-    serializeJson(doc,output);
-    // Publish humidity config to its topic (CCONFIG_TOPIC) as a retained message
-    debugMessage(output,1);
-    pconfigPub.publish(output,true);
-
-    // Reset config data for AQI sensor
-    doc["device_class"] = "aqi";
-    doc["name"] = "aqi";
-    doc["state_topic"] = topic.c_str();
-    doc["unit_of_measurement"] = "hybrid";
-    doc["value_template"] = "{{ value_json.co2}}";
-
-    serializeJson(doc,output);
-    // Publish humidity config to its topic (CCONFIG_TOPIC) as a retained message
-    debugMessage(output,1);
-    aconfigPub.publish(output,true);
-
-    // Reset config data for voc index sensor
-    doc["device_class"] = "voc";
-    doc["name"] = "voc";
-    doc["state_topic"] = topic.c_str();
-    doc["unit_of_measurement"] = "index";
-    doc["value_template"] = "{{ value_json.co2}}";
-
-    serializeJson(doc,output);
-    // Publish humidity config to its topic (CCONFIG_TOPIC) as a retained message
-    debugMessage(output,1);
-    vconfigPub.publish(output,true);
-
-    // Reset config data for co2 sensor
-    doc["device_class"] = "carbon_dioxide";
-    doc["name"] = "CO2";
-    doc["state_topic"] = topic.c_str();
-    doc["unit_of_measurement"] = "ppm";
-    doc["value_template"] = "{{ value_json.co2}}";
-
-    serializeJson(doc,output);
-    // Publish humidity config to its topic (CCONFIG_TOPIC) as a retained message
-    debugMessage(output,1);
-    cconfigPub.publish(output,true);
-  }
+  // Shared helper function
+  extern void debugMessage(String messageText, uint8_t messageLevel);
 
   // Called to publish sensor readings as a JSON payload, as part of overall MQTT
   // publishing as implemented in post_mqtt().  Should only be invoked if 
   // Home Assistant MQTT integration is enabled in config.h.
   // Note that it depends on the value of the state topic matching what's in Home
   // Assistant's configuration file (configuration.yaml).
-  void hassio_mqtt_publish(float pm25, float aqi, float temperatureF, float vocIndex, float humidity) {
-    const int capacity = JSON_OBJECT_SIZE(5);
+  
+  bool hassio_mqtt_publish(float pm25, float co2, float temperatureF, float humidity, float vocIndex, float noxIndex, float aqi) {
+    bool success = false;
+    const int capacity = JSON_OBJECT_SIZE(7);
     StaticJsonDocument<capacity> doc;
 
     // Declare buffer to hold serialized object
     char output[1024];
     String topic;
     // Generate the device state topic for Home Assistant using deployment parameters from
-    // config.h.  Note that this must match the state topic as specified in Home Assiatant's
+    // config.h.  Note that this must match the state topic as specified in Home Assistant's
     // configuration file (configuration.yaml) for this device.
-    topic = String(DEVICE_SITE) + "/" + String(DEVICE) + "/" + String(DEVICE_ID) + "/state";
-    Adafruit_MQTT_Publish pm252StatePub = Adafruit_MQTT_Publish(&aq_mqtt,topic.c_str());
+    topic = "homeassistant/" + endpointPath.site + "/" + endpointPath.location + "/" +
+      endpointPath.room + "/" + endpointPath.deviceID + "/state";
 
-    debugMessage("Publishing RCO2 values to Home Assistant via MQTT (topic below)",1);
+    debugMessage("Publishing Climatron values to Home Assistant via MQTT (state topic below)",1);
     debugMessage(topic,1);
 
+    // Generate the state topic payload (as JSON)
     doc["temperatureF"] = temperatureF;
     doc["humidity"] = humidity;
-    doc["aqi"] = aqi;
+    doc["co2"] = co2;
     doc["pm25"] = pm25;
-    doc["voc"] = vocIndex;
+    doc["vocIndex"] = vocIndex;
+    doc["noxIndex"] = noxIndex;
+    doc["aqi"] = aqi;
 
+    // Serialize the payload so it can be posted via MQTT
     serializeJson(doc,output);
-    // Publish state info to its topic (MQTT_HASSIO_STATE)
-    debugMessage(output,1);
-    pm252StatePub.publish(output);
+    debugMessage(output,1);  // Print the payload for review
+
+    // Publish state info to its topic
+    // Confirm we're connected to the MQTT broker, and if so publish to the state topic
+    if (mqtt.connected()) {
+      if (mqtt.publish(topic.c_str(), output)) {
+        success = true;
+        debugMessage(String("MQTT publish topic is ") + topic + ", message is " + output,2);
+      }
+      else {
+        debugMessage(String("MQTT publish to topic ") + topic + " failed",1);
+      }
+    }
+    else {
+      debugMessage("MQTT not connected during publish to Home Assistant",1);
+    }
+    return success;
   }
 #endif

--- a/post_mqtt.cpp
+++ b/post_mqtt.cpp
@@ -18,19 +18,8 @@
   extern void debugMessage(String messageText, uint8_t messageLevel);
 
   #ifdef HASSIO_MQTT
-    extern void hassio_mqtt_setup();
-    extern void hassio_mqtt_publish(float pm25, float temperatureF, float vocIndex, float humidity);
+    extern bool hassio_mqtt_publish(float pm25, float co2, float temperatureF, float humidity, float vocIndex, float noxIndex, float aqi);
   #endif
-
-  const char* generateMQTTTopic(String key)
-  // Utility function to streamline dynamically generating MQTT topics using site and device 
-  // parameters defined in config.h and our standard naming scheme using values set in secrets.h
-  {
-    String topic = endpointPath.site + "/" + endpointPath.location + "/" + endpointPath.room +
-            "/" + hardwareDeviceType + "/" + endpointPath.deviceID + "/" + key;
-    debugMessage(String("Generated MQTT topic: ") + topic,2);
-    return(topic.c_str());
-  }
 
   bool mqttConnect() {
     bool connected = false;
@@ -55,25 +44,6 @@
       }
     }
     return connected;
-  }
-
-  bool mqttPublish(const char* topic, const String& payload) {
-    bool success = false;
-
-    if (mqtt.connected()) {
-      if (mqtt.publish(topic, payload.c_str())) {
-        success = true;
-        // IMPROVEMENT: topic is not being printed?
-        debugMessage(String("MQTT publish topic is ") + topic + ", message is " + payload,2);
-      }
-      else
-        // IMPROVEMENT: topic is not being printed
-        debugMessage(String("MQTT publish to topic ") + topic + " failed",1);
-    }
-    else {
-      debugMessage("MQTT not connected during publish",1);
-    }
-    return success;
   }
 
   // Publish a value to MQTT, synthesizing the relevant topic based on device and site

--- a/powered_air_quality.ino
+++ b/powered_air_quality.ino
@@ -157,7 +157,7 @@ extern uint8_t noxRange(float);
   extern bool mqttPublishValue(String key, const String& payload);
 
   #ifdef HASSIO_MQTT
-    extern void hassio_mqtt_publish(float pm25, float temperatureF, float vocIndex, float humidity, uint16_t co2);
+    extern bool hassio_mqtt_publish(float pm25, float co2, float temperatureF, float humidity, float vocIndex, float noxIndex, float aqi);
   #endif
 #endif
 
@@ -692,6 +692,7 @@ void samplePost(uint8_t& numSamples)
         float avgVOC = totalVOCIndex.getAverage();
         float avgPM25 = totalPM25.getAverage();
         float avgNOX = totalNOxIndex.getAverage();
+        float aqi = pm25toAQI_US(avgPM25);
 
         debugMessage(String("Averages being sent to endpoints for the last ") + (timeReportMS/60000) + " minutes",2);
         debugMessage(String("PM2.5: ") + avgPM25 + "ppm, CO2: " + avgCO2 + "ppm, VOC index: " + avgVOC + ", NOx index: " + avgNOX + ", " + 
@@ -733,7 +734,7 @@ void samplePost(uint8_t& numSamples)
               // Either configure sensors in Home Assistant's configuration.yaml file
               // directly or attempt to do it via MQTT auto-discovery
               // hassio_mqtt_setup();  // Config for MQTT auto-discovery
-              hassio_mqtt_publish(avgPM25, avgTemperatureF, avgVOC, avgHumidity);
+              hassio_mqtt_publish(avgPM25, avgCO2, avgTemperatureF, avgHumidity, avgVOC, avgNOX, aqi);
             #endif
 
             mqtt.disconnect();

--- a/secrets_template.h
+++ b/secrets_template.h
@@ -6,8 +6,8 @@
 // Configuration Step 1: Set default device latitude, longitude, altitude.
 // These values will populate the web configuration portal until replaced by the user
 // const String kDefaultAltitude = "0"; // meters
-// const String kdefaultLatitude = "0";
-// const String kdefaultLongitude = "0";
+// const String kDefaultLatitude = "0";
+// const String kDefaultLongitude = "0";
 
 // Configuration Step 2: Set Open Weather Map credential
 //	const String OWMKey =		"keyvalue";


### PR DESCRIPTION
Work in this branch focused on updating MQTT-based Home Assistant integration, allowing Climatron sensors to be visible in the Home Assistant user interface and (better yet), used as triggers in Home Assistant automations (e.g., to turn on a fan when CO2 levels are elevated).